### PR TITLE
Github ActionsによるCDの導入

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,37 @@
+name: Github Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node.
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+
+      - name: Install packages.
+        run: npm ci
+
+      - name: Build sources.
+        run: npm run build
+
+      - name: Export built sources.
+        run: npm run export
+
+      - name: Not use Jekyll because '_' prefixed files are not found.
+        run: touch ./out/.nojekyll
+
+      - name: Deploy to Github Pages.
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./out
+          cname: blog.matsudai.net

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Success! Created matsudai.github.io at C:\xxxxx\matsudai.github.io.
 > git mv styles src\
 ```
 
+## Add Github Actions
+
+refs: [https://github.com/peaceiris/actions-gh-pages#⭐️ React and Next](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-react-and-next)
+
 ## Getting Started
 
 First, run the development server:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "export": "next export",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
* Next.jsのビルド後に実行する静的ページ出力コマンド `npm run export`  の追加
* rootからトップページにアクセスできるファイルを出力するワークフローの追加