### PR TITLE
Prettierの環境の修正

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,9 +7,7 @@ module.exports = {
   extends: [
     'plugin:react/recommended',
     'airbnb',
-    "prettier",
-    "prettier/@typescript-eslint",
-    "prettier/react"
+    'prettier'
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ In order to use breakpoints.
     * Run "Next: Attach Backend" - for SSR
     * Run "Next: Launch Chrome"  - for CSR
 
+## Prettier
+
+```txt
+> npm i -D prettier eslint-config-prettier
+```
+
 ## Add Github Actions
 
 refs: [https://github.com/peaceiris/actions-gh-pages#⭐️ React and Next](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-react-and-next)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3049,6 +3049,12 @@
         "object.entries": "^1.1.2"
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz",
+      "integrity": "sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==",
+      "dev": true
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
@@ -6127,6 +6133,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
     "pretty-hrtime": {

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "@typescript-eslint/parser": "^4.11.1",
     "eslint": "^7.16.0",
     "eslint-config-airbnb": "^18.2.1",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "http-server": "^0.12.3",
+    "prettier": "^2.2.1",
     "typescript": "^4.1.3"
   }
 }


### PR DESCRIPTION
#10 の修正です。

ESLint8.0.0からprettier/reactなどが不必要になりました。